### PR TITLE
Also throw the error native_require returns

### DIFF
--- a/lib/require.js
+++ b/lib/require.js
@@ -21,7 +21,7 @@ function require(p, root) {
     try {
       return native_require(p);
     } catch (err) {
-      throw new Error('failed to require "' + p + '" from ' + root);
+      throw new Error('failed to require "' + p + '" from ' + root +'\n' + err.message + '\n' + err.stack);
     }
   }
 


### PR DESCRIPTION
Useful when requiring external entities that may or may not have errors in them.

(My use case: Distributed Node program that uses external addons)